### PR TITLE
Problem: Not using naming conventions for Go constants.

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -62,7 +62,7 @@ func (i *Interpreter) Eval(ctx context.Context, node ast.Node, scope *objects.Sc
 			res = i.Eval(ctx, s, scope)
 			if res != nil {
 				switch res.Type() {
-				case objects.CONTINUE:
+				case objects.ContinueType:
 					return res
 				}
 			}
@@ -206,17 +206,17 @@ func (i *Interpreter) evalInfixBooleanExpression(operator string, left, right bo
 
 func (i *Interpreter) evalInfixExpression(operator string, left, right objects.Object) objects.Object {
 	switch left.Type() {
-	case objects.INTEGER:
+	case objects.IntegerType:
 		switch right.Type() {
-		case objects.INTEGER:
+		case objects.IntegerType:
 			l := left.(*objects.Integer).Value
 			r := right.(*objects.Integer).Value
 			return i.evalInfixIntegerExpression(operator, l, r)
 		}
 
-	case objects.BOOLEAN:
+	case objects.BooleanType:
 		switch right.Type() {
-		case objects.BOOLEAN:
+		case objects.BooleanType:
 			l := left.(*objects.Boolean).Value
 			r := right.(*objects.Boolean).Value
 			return i.evalInfixBooleanExpression(operator, l, r)
@@ -266,7 +266,7 @@ func (i *Interpreter) evalForStatement(ctx context.Context, node *ast.ForStateme
 
 		if body != nil {
 			switch body.Type() {
-			case objects.CONTINUE:
+			case objects.ContinueType:
 				continue
 			}
 		}
@@ -287,7 +287,7 @@ func (i *Interpreter) evalIfStatement(ctx context.Context, node *ast.IfStatement
 	body := i.Eval(ctx, node.Body, scope)
 	if body != nil {
 		switch body.Type() {
-		case objects.CONTINUE:
+		case objects.ContinueType:
 			return body
 		}
 	}

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -28,8 +28,8 @@ type Integer struct {
 	Value int
 }
 
-// Type returns INTEGER.
-func (i *Integer) Type() Type { return INTEGER }
+// Type returns IntegerType.
+func (i *Integer) Type() Type { return IntegerType }
 
 func (i *Integer) String() string { return strconv.Itoa(i.Value) }
 
@@ -38,8 +38,8 @@ type Boolean struct {
 	Value bool
 }
 
-// Type returns BOOLEAN.
-func (b *Boolean) Type() Type { return BOOLEAN }
+// Type returns BooleanType.
+func (b *Boolean) Type() Type { return BooleanType }
 
 func (b *Boolean) String() string { return strconv.FormatBool(b.Value) }
 
@@ -48,16 +48,16 @@ type String struct {
 	Value string
 }
 
-// Type returns STRING.
-func (s *String) Type() Type { return STRING }
+// Type returns StringType.
+func (s *String) Type() Type { return StringType }
 
 func (s *String) String() string { return s.Value }
 
 // Continue represents continue runtime object.
 type Continue struct{}
 
-// Type returns CONTINUE.
-func (c *Continue) Type() Type { return CONTINUE }
+// Type returns ContinueType.
+func (c *Continue) Type() Type { return ContinueType }
 
 func (c *Continue) String() string {
 	return "continue"
@@ -70,8 +70,8 @@ type Function struct {
 	Scope      *Scope
 }
 
-// Type returns FUNCTION.
-func (f *Function) Type() Type { return FUNCTION }
+// Type returns FunctionType.
+func (f *Function) Type() Type { return FunctionType }
 
 func (f *Function) String() string {
 	params := make([]string, len(f.Parameters))
@@ -92,8 +92,8 @@ type GoFunction struct {
 	Func func(args ...Object) Object
 }
 
-// Type returns GOFUNCTION.
-func (gf *GoFunction) Type() Type { return GOFUNCTION }
+// Type returns GoFunctionType.
+func (gf *GoFunction) Type() Type { return GoFunctionType }
 
 func (gf *GoFunction) String() string { return reflect.ValueOf(gf.Func).String() }
 

--- a/objects/type.go
+++ b/objects/type.go
@@ -14,10 +14,10 @@ type Type int
 
 // The list of object types.
 const (
-	INTEGER Type = iota
-	BOOLEAN
-	STRING
-	FUNCTION
-	GOFUNCTION
-	CONTINUE
+	IntegerType Type = iota
+	BooleanType
+	StringType
+	FunctionType
+	GoFunctionType
+	ContinueType
 )

--- a/objects/type_string.go
+++ b/objects/type_string.go
@@ -4,9 +4,9 @@ package objects
 
 import "strconv"
 
-const _Type_name = "INTEGERBOOLEANSTRINGFUNCTIONGOFUNCTIONCONTINUE"
+const _Type_name = "IntegerTypeBooleanTypeStringTypeFunctionTypeGoFunctionTypeContinueType"
 
-var _Type_index = [...]uint8{0, 7, 14, 20, 28, 38, 46}
+var _Type_index = [...]uint8{0, 11, 22, 32, 44, 58, 70}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {


### PR DESCRIPTION
Solution: Use CamelCase for constants.

The names are suffixed with `Type` since otherwise they would collide
with the types defined with the same names. Closes #17 

Please let me know if you don't like the extra `Type` suffix and have better ideas.