### PR TITLE
Problem: log.Fatalf message contains trailing period

### DIFF
--- a/misc/run_fuzzer.go
+++ b/misc/run_fuzzer.go
@@ -64,7 +64,7 @@ func main() {
 	file := filepath.Join(workdir, pack+"_fuzz.zip")
 
 	if _, err := os.Stat(workdir); err != nil {
-		log.Fatalf("%s.\nRun tests with `make` to create working directory and initial go-fuzz corpus.", err)
+		log.Fatalf("%s.\nRun tests with `make` to create working directory and initial go-fuzz corpus", err)
 	}
 
 	run("go", "install", "-v", "-tags", "gofuzz", "./...")


### PR DESCRIPTION
Solution: remove excessive punctuation

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>

